### PR TITLE
Fix NilClass error when there is no `katex:` key in a user's jekyll

### DIFF
--- a/lib/jekyll-katex/configuration.rb
+++ b/lib/jekyll-katex/configuration.rb
@@ -16,7 +16,7 @@ module Jekyll
         }
       }.freeze
 
-      JEKYLL_CONFIG = Jekyll.configuration['katex']
+      JEKYLL_CONFIG = Jekyll.configuration['katex'] || {}
 
       def self.js_path
         js_filename = JEKYLL_CONFIG['js_filename'] || CONFIG_DEFAULTS[:js_filename]

--- a/lib/jekyll-katex/version.rb
+++ b/lib/jekyll-katex/version.rb
@@ -2,6 +2,6 @@
 
 module Jekyll
   module Katex
-    VERSION = '0.2.0'
+    VERSION = '0.2.1'
   end
 end


### PR DESCRIPTION
Fix to #3 .