### PR TITLE
Add support for macro option in rendering_options

### DIFF
--- a/lib/jekyll-katex/configuration.rb
+++ b/lib/jekyll-katex/configuration.rb
@@ -13,7 +13,8 @@ module Jekyll
         'js_path' => File.join(Jekyll::Katex::LIB_ROOT, 'assets', 'js'),
         'rendering_options' => {
           'throw_error' => true,
-          'error_color' => '#cc0000'
+          'error_color' => '#cc0000',
+          'macros' => {}
         }
       }.freeze
 
@@ -40,7 +41,8 @@ module Jekyll
       def self.global_rendering_options
         {
           throwOnError: CONFIG['rendering_options']['throw_error'],
-          errorColor: CONFIG['rendering_options']['error_color']
+          errorColor: CONFIG['rendering_options']['error_color'],
+          macros: CONFIG['rendering_options']['macros']
         }
       end
     end


### PR DESCRIPTION
As discussed in #16 the option to add custom macros would be helpful. I've simply added the macro object to the `rendering_options` as specified at [https://katex.org/docs/next/options.html](https://katex.org/docs/next/options.html). 

Following the example provided at the link above, the configuration:

```yaml
katex:
  rendering_options:
    macros: 
      "\\RR": "\\mathbb{R}"
```

Gives the ability to write 

```
{% katex display %}
\RR
{% endkatex %}
```
For the following output 
![image](https://user-images.githubusercontent.com/3295293/95883369-c0fa6400-0d72-11eb-819c-335f7f052f2f.png)

Arguments are also supported. E.g.

```yaml
katex:
  rendering_options:
    macros: 
      "\\RRArg": "\\mathbb{#1}"
```

and

```
{% katex display %}
\RRArg{R}
{% endkatex %}
```

Results in the same output.
